### PR TITLE
cluster-ui: statement details styles

### DIFF
--- a/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -1,4 +1,5 @@
 @import "src/core/index.module";
+@import "~@cockroachlabs/design-tokens/dist/web/tokens";
 
 $max-window-width: 1350px;
 
@@ -141,5 +142,12 @@ h2.base-heading {
   &__col-query-text {
     font-family: $font-family--monospace;
     white-space: pre-wrap;
+  }
+}
+
+.summary-card {
+  color: $colors--neutral-7;
+  h5 {
+    color: $colors--neutral-7;
   }
 }

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -436,7 +436,7 @@ export class StatementDetails extends React.Component<
           </Row>
           <Row gutter={16}>
             <Col className="gutter-row" span={8}>
-              <SummaryCard>
+              <SummaryCard className={cx("summary-card")}>
                 <Row>
                   <Col>
                     <div className={summaryCardStylesCx("summary--card__item")}>
@@ -469,10 +469,10 @@ export class StatementDetails extends React.Component<
                   </Col>
                 </Row>
               </SummaryCard>
-              <SummaryCard>
+              <SummaryCard className={cx("summary-card")}>
                 <Heading type="h5">Resource usage</Heading>
-                <Row gutter={24}>
-                  <Col span={12}>
+                <Row>
+                  <Col>
                     <div className={summaryCardStylesCx("summary--card__item")}>
                       <Text type="body-strong">Mean rows/bytes read</Text>
                       <Text>
@@ -481,8 +481,6 @@ export class StatementDetails extends React.Component<
                         {formatNumberForDisplay(stats.bytes_read.mean, Bytes)}
                       </Text>
                     </div>
-                  </Col>
-                  <Col span={12}>
                     <div className={summaryCardStylesCx("summary--card__item")}>
                       <Text type="body-strong">Max memory usage</Text>
                       <Text>
@@ -506,7 +504,7 @@ export class StatementDetails extends React.Component<
               </SummaryCard>
             </Col>
             <Col className="gutter-row" span={8}>
-              <SummaryCard>
+              <SummaryCard className={cx("summary-card")}>
                 <Heading type="h5">Statement details</Heading>
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text type="body-strong">App</Text>


### PR DESCRIPTION
- "Resource usage" section is changed to have a single column (according
to last Anne's [comment](https://github.com/cockroachdb/ui/pull/216#issuecomment-781741456))
- Applied Neutral 7 color for both headers and text inside of Summary cards
